### PR TITLE
refactor(purge): remove bypassPurge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ need to make all of the links up front before using them, you can simply
 _always_ create the links where you need them and know that it will either be
 created or a cached copy will be returned.
 
+By default receiver links are _not_ cached, the user must explicitly opt in to
+this behavior for both receiver links and receiver streams.
+
 ## usage
 ```javascript
 'use strict';
@@ -22,26 +25,28 @@ client.connect('amqp://localhost')
   .then(function() {
     // defaults for sender:
     var senderOpts = {
-      bypassPurge: false,      // set to true to disable purging after ttl
       bypassCache: false      // set to true to disable caching this link
     };
 
     // defaults for receiver:
     var receiverOpts = {
-      bypassPurge: true,      // receivers will bypass purge by default
-      bypassCache: false
+      bypassCache: true
     };
 
     return Promise.all([
       client.createSender('amq.topic', senderOpts),
       client.createSender('amq.topic'),
+      client.createSender('amq.topic', { bypassCache: true }),
       client.createReceiver('amqp.topic', receiverOpts),
       client.createReceiver('amqp.topic'),
-      client.createReceiver('amqp.topic', { bypassCache: true })
+      client.createReceiver('amq.topic', { bypassCache: false }),
+      client.createReceiver('amq.topic', { bypassCache: false })
     ]);
   })
-  .spread(function(sender1, sender2, rec1, rec2, rec3) {
+  .spread(function(sender1, sender2, sender3, receiver1, receiver2, receiver3, receiver4) {
     // sender1 === sender2
-    // rec1 === rec2 !== rec3
+    // sender1 !== sender3 && sender2 !== sender3
+    // receiver1 !== receiver2
+    // receiver3 === receiver4
   });
 ```

--- a/index.js
+++ b/index.js
@@ -13,13 +13,13 @@ function createLink(client, address, options, type, method) {
   }
 
   options = options || {};
-  if (options.hasOwnProperty('bypassCache') && !!options.bypassCache) {
-    return method(address, options);
+  if (!options.hasOwnProperty('bypassCache')) {
+    options.bypassCache =
+      (type === 'receiver' || type === 'receiverStream') ? true : false;
   }
 
-  if (!options.hasOwnProperty('bypassPurge')) {
-    options.bypassPurge =
-      (type === 'receiver' || type === 'receiverStream') ? true : false;
+  if (!!options.bypassCache) {
+    return method(address, options);
   }
 
   var linkHash = hash({ type: type, address: address, options: options });
@@ -42,7 +42,7 @@ function createLink(client, address, options, type, method) {
       });
 
       client.links[linkHash] = { link: link, stamp: Date.now() };
-      if (!purgeTimeout && !options.bypassPurge) {
+      if (!purgeTimeout) {
         purgeTimeout = setTimeout(function() { purgeLinks(client); }, ttl);
       }
 

--- a/test/purge.test.js
+++ b/test/purge.test.js
@@ -69,19 +69,6 @@ describe('purging', function() {
       });
   });
 
-  it('should not purge links that indicate they should bypass purge', function() {
-    var sender;
-    return test.client.connect(config.address)
-      .then(function() { return test.client.createSender('amq.topic', { bypassPurge: true }); })
-      .then(function(s) { sender = s; })
-      .delay(100)
-      .then(function() {
-        var state = sender.linkSM.getMachineState();
-        expect(state).to.equal('ATTACHED');
-        sender = null;
-      });
-  });
-
   it('should not purge receiver links by default', function() {
     var receiver;
     return test.client.connect(config.address)


### PR DESCRIPTION
While bypassing purge worked in isolated integration tests, it did
not in practice. Bypassing purge simply did not kick off the purge
timer for the newly created link, however if the timer was active
for any other links it would still purge the links which the user
requested not be purged.

This patch takes the alternate solution discussed in defaulting to
not caching receiver links, and instead making this feature an
explicit opt-in for those link/stream types.